### PR TITLE
Fix nginx paths for Next.js static assets

### DIFF
--- a/nginx/john-galt.conf
+++ b/nginx/john-galt.conf
@@ -1,12 +1,16 @@
+# Node.js SSR server for Next.js
 upstream frontend {
     server 127.0.0.1:3000;
 }
 
+# FastAPI backend
 upstream api {
     server 127.0.0.1:8000;
 }
 
 server {
+    # HTTP entry point. HTTPS termination could be handled by a load balancer or
+    # additional nginx configuration.
     listen 80;
     server_name example.com;
 
@@ -20,6 +24,14 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Serve Next.js build assets directly from disk
+    location /_next/static/ {
+        alias /var/www/John_Galt_Panel/frontend/.next/standalone/.next/static/;
+        access_log off;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # Proxy all other Next.js requests to the standalone server
     location /_next/ {
         proxy_pass http://frontend;
         proxy_http_version 1.1;
@@ -30,8 +42,15 @@ server {
         proxy_cache_valid 200 1h;
     }
 
+    # Public assets from Next.js "public" directory
     location /static/ {
         alias /var/www/John_Galt_Panel/frontend/public/;
+        access_log off;
+        expires 30d;
+    }
+
+    location /images/ {
+        alias /var/www/John_Galt_Panel/frontend/public/images/;
         access_log off;
         expires 30d;
     }
@@ -45,5 +64,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' http://localhost:8000; object-src 'none';";
+    # Basic Content-Security-Policy. Replace 'unsafe-inline' with nonces or hashes
+    # for stronger security if desired.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' http://127.0.0.1:8000; object-src 'none';" always;
 }


### PR DESCRIPTION
## Summary
- serve `_next/static` directly from the standalone build
- expose public images and other assets via nginx
- document basic Content-Security-Policy header

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6864110238348332a8922788564f1826