### PR TITLE
Fix path for Next.js build and update deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,22 @@ Environment variables are documented in `.env.example`.
 
 The `nginx/john-galt.conf` file contains an example reverse proxy
 configuration for serving the Next.js SSR frontend and FastAPI backend.
+
+## Production Deployment
+
+1. Build the frontend:
+
+   ```bash
+   cd frontend
+   npm install
+   npm run build
+   ```
+
+2. Start the server with **PM2**:
+
+   ```bash
+   pm2 start npm --name john-galt-frontend -- start
+   ```
+
+3. Ensure nginx serves `/_next/static/` from `<project>/frontend/.next/static/` as
+   shown in `nginx/john-galt.conf`.

--- a/deploy-full.sh
+++ b/deploy-full.sh
@@ -14,7 +14,8 @@ npm run build || { echo "❌ Ошибка сборки"; exit 1; }
 
 echo "🚀 Перезапуск SSR через pm2..."
 pm2 delete john-galt-frontend || true
-pm2 start .next/standalone/server.js --name john-galt-frontend
+# Start the built Next.js app using `next start` instead of standalone server.js
+pm2 start npm --name john-galt-frontend -- start
 
 cd ..
 

--- a/frontend/deploy.sh
+++ b/frontend/deploy.sh
@@ -12,7 +12,9 @@ npm run build
 
 echo "🚀 [3/5] Перезапуск SSR через pm2..."
 pm2 delete john-galt-frontend || true
-pm2 start .next/standalone/server.js --name john-galt-frontend
+# Next.js 15 no longer generates a standalone server.js by default.
+# Use `next start` via npm to serve the built app on port 3000.
+pm2 start npm --name john-galt-frontend -- start
 
 echo "🔄 [4/5] Перезапуск nginx..."
 sudo systemctl reload nginx

--- a/nginx/john-galt.conf
+++ b/nginx/john-galt.conf
@@ -25,8 +25,10 @@ server {
     }
 
     # Serve Next.js build assets directly from disk
+    # In Next.js 15 the standalone folder no longer contains "_next/static".
+    # Static files are emitted into ".next/static" directly.
     location /_next/static/ {
-        alias /var/www/John_Galt_Panel/frontend/.next/standalone/.next/static/;
+        alias /var/www/John_Galt_Panel/frontend/.next/static/;
         access_log off;
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
@@ -64,7 +66,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Basic Content-Security-Policy. Replace 'unsafe-inline' with nonces or hashes
-    # for stronger security if desired.
+    # Basic Content-Security-Policy. Next.js injects inline scripts/styles for
+    # hydration so 'unsafe-inline' is required unless you use nonces/hashes.
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' http://127.0.0.1:8000; object-src 'none';" always;
 }

--- a/panel.sh
+++ b/panel.sh
@@ -34,7 +34,7 @@ case "$1" in
 
     echo "🧹 Перезапуск SSR-сервера через pm2..."
     pm2 delete john-galt-frontend || true
-    pm2 start .next/standalone/server.js --name john-galt-frontend
+    pm2 start npm --name john-galt-frontend -- start
 
     exit 0
     ;;

--- a/rollback.sh
+++ b/rollback.sh
@@ -6,7 +6,8 @@ echo "♻️ Откат из резервной копии..."
 cd frontend
 git reset --hard HEAD~1 || true
 pm2 delete john-galt-frontend || true
-pm2 start .next/standalone/server.js --name john-galt-frontend
+# Use npm start to run the built Next.js app after rollback
+pm2 start npm --name john-galt-frontend -- start
 
 echo "🔄 Перезапуск Nginx..."
 sudo systemctl reload nginx


### PR DESCRIPTION
## Summary
- correct Nginx static asset path for Next.js 15
- clarify CSP comment
- run `next start` with pm2 instead of missing `server.js`
- adjust deploy/rollback scripts
- document production run instructions

## Testing
- `npm test --prefix frontend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686414764c6c83329a27a104fdf51382