### PR TITLE
Fix access control with RequireRole

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const PROTECTED = [
+  '/dashboard',
+  '/admin',
+  '/inventory',
+  '/settings',
+  '/profile',
+  '/users'
+];
+
+function parseJwt(token: string) {
+  try {
+    const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+    return JSON.parse(Buffer.from(base64, 'base64').toString());
+  } catch {
+    return null;
+  }
+}
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  if (PROTECTED.some((p) => pathname.startsWith(p))) {
+    const token = req.cookies.get('token')?.value;
+    if (!token) {
+      return NextResponse.redirect(new URL('/login', req.url));
+    }
+    const payload = parseJwt(token);
+    if (!payload || (payload.role !== 'admin' && payload.role !== 'staff')) {
+      return NextResponse.redirect(new URL('/unauthorized', req.url));
+    }
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*','/admin/:path*','/inventory/:path*','/settings/:path*','/profile/:path*','/users/:path*']
+};

--- a/frontend/src/app/(admin)/page.tsx
+++ b/frontend/src/app/(admin)/page.tsx
@@ -1,15 +1,19 @@
-import type { Metadata } from "next";
-import React from "react";
+"use client";
+import { useAuth } from "@/context/AuthContext";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
-export const metadata: Metadata = {
-  title: "Панель управления | John Galt Company",
-  description: "Начальная страница административной панели",
-};
+export default function Home() {
+  const { user } = useAuth();
+  const router = useRouter();
 
-export default function Dashboard() {
-  return (
-    <div className="p-6 rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/5">
-      <h1 className="text-xl font-semibold text-gray-800 dark:text-white/90">Панель управления</h1>
-    </div>
-  );
+  useEffect(() => {
+    if (user) {
+      router.replace("/dashboard");
+    } else {
+      router.replace("/login");
+    }
+  }, [user, router]);
+
+  return null;
 }

--- a/frontend/src/app/(admin)/users/create/page.tsx
+++ b/frontend/src/app/(admin)/users/create/page.tsx
@@ -1,6 +1,7 @@
 import RequireRole from '@/components/auth/RequireRole';
 import UserCreateForm from '@/components/users/UserCreateForm';
 import type { Metadata } from 'next';
+import { Role } from '@/types';
 
 export const metadata: Metadata = {
   title: 'Создать пользователя | John Galt Company',
@@ -8,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function UserCreatePage() {
   return (
-    <RequireRole roles={["admin"]}>
+    <RequireRole roles={[Role.Admin]}>
       <UserCreateForm />
     </RequireRole>
   );

--- a/frontend/src/app/(admin)/users/page.tsx
+++ b/frontend/src/app/(admin)/users/page.tsx
@@ -1,6 +1,7 @@
 import RequireRole from '@/components/auth/RequireRole';
 import UserTable from '@/components/users/UserTable';
 import type { Metadata } from 'next';
+import { Role } from '@/types';
 
 export const metadata: Metadata = {
   title: 'Пользователи | John Galt Company',
@@ -8,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function UsersPage() {
   return (
-    <RequireRole roles={["admin"]}>
+    <RequireRole roles={[Role.Admin]}>
       <UserTable />
     </RequireRole>
   );

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,8 +1,9 @@
 import RequireRole from "@/components/auth/RequireRole";
+import { Role } from "@/types";
 
 export default function AdminPage() {
   return (
-    <RequireRole roles={["admin"]}>
+    <RequireRole roles={[Role.Admin]}>
       <div className="p-6">Админ страница</div>
     </RequireRole>
   );

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import React from "react";
 import RequireRole from "@/components/auth/RequireRole";
+import { Role } from "@/types";
 
 export const metadata: Metadata = {
   title: "Панель управления | John Galt Company",
@@ -9,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function Dashboard() {
   return (
-    <RequireRole roles={["admin", "staff", "viewer"]}>
+    <RequireRole roles={[Role.Admin, Role.Staff]}>
       <div className="p-6 rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/5">
         <h1 className="text-xl font-semibold text-gray-800 dark:text-white/90">Панель управления</h1>
       </div>

--- a/frontend/src/app/inventory/page.tsx
+++ b/frontend/src/app/inventory/page.tsx
@@ -1,8 +1,9 @@
 import RequireRole from "@/components/auth/RequireRole";
+import { Role } from "@/types";
 
 export default function InventoryPage() {
   return (
-    <RequireRole roles={["admin", "staff"]}>
+    <RequireRole roles={[Role.Admin, Role.Staff]}>
       <div className="p-6">Инвентарь</div>
     </RequireRole>
   );

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,8 +1,9 @@
 import RequireRole from "@/components/auth/RequireRole";
+import { Role } from "@/types";
 
 export default function Profile() {
   return (
-    <RequireRole roles={["admin", "staff", "viewer"]}>
+    <RequireRole roles={[Role.Admin, Role.Staff, Role.Viewer]}>
       <div className="p-6">Профиль пользователя</div>
     </RequireRole>
   );

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,8 +1,9 @@
 import RequireRole from "@/components/auth/RequireRole";
+import { Role } from "@/types";
 
 export default function SettingsPage() {
   return (
-    <RequireRole roles={["admin", "staff"]}>
+    <RequireRole roles={[Role.Admin, Role.Staff]}>
       <div className="p-6">Настройки</div>
     </RequireRole>
   );

--- a/frontend/src/components/auth/RequireRole.tsx
+++ b/frontend/src/components/auth/RequireRole.tsx
@@ -2,13 +2,14 @@
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useAuth } from "@/context/AuthContext";
+import { Role } from "@/types";
 
 export default function RequireRole({
   children,
   roles,
 }: {
   children: React.ReactNode;
-  roles: string[];
+  roles: Role[];
 }) {
   const { user } = useAuth();
   const router = useRouter();

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { createContext, useContext, useEffect, useState } from "react";
-
-type Role = "admin" | "staff" | "viewer";
+import { Role } from "@/types";
 
 export type User = {
   id: number;
@@ -34,6 +33,12 @@ function parseJwt(token: string): TokenPayload | null {
   }
 }
 
+function getCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(new RegExp(`(^| )${name}=([^;]+)`));
+  return match ? match[2] : null;
+}
+
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
@@ -48,25 +53,32 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         role: payload.role as Role,
       });
       localStorage.setItem("token", token);
+      document.cookie = `token=${token}; path=/; SameSite=Lax`;
     } else {
       setUser(null);
       localStorage.removeItem("token");
+      document.cookie = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
     }
   };
 
   const logout = () => {
     setUser(null);
     localStorage.removeItem("token");
+    document.cookie = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
   };
 
   useEffect(() => {
-    const stored = localStorage.getItem("token");
-    if (stored) {
-      const payload = parseJwt(stored);
+    const stored =
+      typeof window !== "undefined" ? localStorage.getItem("token") : null;
+    const cookieToken = getCookie("token");
+    const token = stored || cookieToken;
+    if (token) {
+      const payload = parseJwt(token);
       if (payload && payload.exp * 1000 > Date.now()) {
-        login(stored);
+        login(token);
       } else {
         localStorage.removeItem("token");
+        document.cookie = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
       }
     }
   }, []);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,5 @@
+export enum Role {
+  Admin = 'admin',
+  Staff = 'staff',
+  Viewer = 'viewer'
+}


### PR DESCRIPTION
## Summary
- add Role enum
- update RequireRole to use Role enum
- enforce role checks across admin pages
- redirect from `/` based on auth
- save auth token in cookies as well as localStorage
- add middleware for server-side access control

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68644563da24833296fc549c417f73ca